### PR TITLE
feat: make props optional on push modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,6 @@ type PushModalOptions = {
 - Add option to enable/disable close on click outside
 - Add option to enable/disable press ESC to close
 
-## Issues 
+## Issues
 
-### pushModal
-
-`pushModal` is smart but still not smart enough. It'll infer types from your components. But if you want to push a modal that does not have any props `pushModal('Modal1')` typescript will complain. You will need to do `pushModal('Modal1', {})` (PR's are welcome to fix this 😅)
+Known issues will be listed here

--- a/src/lib/factory.example.tsx
+++ b/src/lib/factory.example.tsx
@@ -14,13 +14,13 @@ export function FactoryExample() {
               <div className="flex gap-4">
                 <button
                   className="bg-black text-white px-4 py-2 rounded-md"
-                  onClick={() => pushModal('ModalExample', {})}
+                  onClick={() => pushModal('ModalExample')}
                 >
                   Open Modal
                 </button>
                 <button
                   className="bg-black text-white px-4 py-2 rounded-md"
-                  onClick={() => pushModal('SheetExample', {})}
+                  onClick={() => pushModal('SheetExample')}
                 >
                   Open Sheet
                 </button>
@@ -32,13 +32,13 @@ export function FactoryExample() {
               <div className="flex gap-4">
                 <button
                   className="bg-black text-white px-4 py-2 rounded-md"
-                  onClick={() => pushModal('ModalExample', {})}
+                  onClick={() => pushModal('ModalExample')}
                 >
                   Open Modal
                 </button>
                 <button
                   className="bg-black text-white px-4 py-2 rounded-md"
-                  onClick={() => pushModal('SheetExample', {})}
+                  onClick={() => pushModal('SheetExample')}
                 >
                   Open Sheet
                 </button>
@@ -63,13 +63,13 @@ export function FactoryExample() {
       <div className="flex gap-4">
         <button
           className="bg-black text-white px-4 py-2 rounded-md"
-          onClick={() => pushModal('ModalExample', {})}
+          onClick={() => pushModal('ModalExample')}
         >
           Open Modal
         </button>
         <button
           className="bg-black text-white px-4 py-2 rounded-md"
-          onClick={() => pushModal('SheetExample', {})}
+          onClick={() => pushModal('SheetExample')}
         >
           Open Sheet
         </button>

--- a/src/lib/factory.tsx
+++ b/src/lib/factory.tsx
@@ -148,21 +148,27 @@ export function createPushModal<T>({
   type GetComponentProps<T> = T extends React.ComponentType<infer P> | React.Component<infer P>
     ? P
     : never;
-  type OrUndefined<T> = T extends Record<string | number | symbol, never> ? undefined : T;
+  type GetDefinedProps<T> = T extends Record<string | number | symbol, unknown> ? T : never;
 
   const pushModal = <
     T extends StateItem['name'],
-    B extends OrUndefined<GetComponentProps<(typeof modals)[T]['Component']>>,
+    B extends GetComponentProps<(typeof modals)[T]['Component']>,
   >(
     name: T,
-    props: B,
-    options?: PushModalOptions
-  ) =>
-    emitter.emit('push', {
+    ...args: GetDefinedProps<B> extends never
+      ? // No props provided
+        [props?: undefined, options?: PushModalOptions]
+      : // Props provided
+        [props: B, options?: PushModalOptions]
+  ) => {
+    const [props, options] = args;
+
+    return emitter.emit('push', {
       name,
       props: props ?? {},
       options,
     });
+  };
 
   // const replaceModal = <
   //   T extends StateItem['name'],


### PR DESCRIPTION
Hi, thanks for this lib, I was the one who replied you about asking if you had already deployed it, thanks for this library, it will help a bunch.

I saw that in your README, you've listed an issue where `pushModal` required you to pass an empty object even if there were no props, so this PR solves this issue(but I can't assure it's the best way of doing it).

Now this is possible:

```ts
pushModal('ModalExample')
// and also
pushModal('SheetExample')
```

### Issue I noticed

I also noticed another problem, but I couldn't figure it out for now, but it was already happening before this PR.


#### Example

If the component accepts no props, you can still pass an object with any property, for example using the `ModalExample` that accepts no props.

This will work:
```ts
pushModal(
  'ModalExample',
  {},
  {
    Wrapper: SheetWrapper,
  }
)
```

And this will also work:

```ts
pushModal(
  'ModalExample',
  { fakeProp: true },
  {
    Wrapper: SheetWrapper,
  }
)
```

What I intended on doing was to only allow not passing the second parameter, or allow the user to pass `undefined`, but it is somehow allowing any obj.