### PR TITLE
fix: allow interface + remove second param(props) if component does not require props

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,16 +145,7 @@ replaceWithModal('SheetExample', { /* Props if any */ })
 
 ## Issues / Limitations
 
-- Use `type` instead of `interface` since we cannot infer the props from you modal! *Not sure why this is...*
-
-```ts
-// BAD
-interface MyModalProps {
-  bar: string
-}
-// GOOD
-type MyModalProps = { bar: string }
-```
+Issues or limitations will be listed here.
 
 ## Contributors
 

--- a/src/lib/factory.tsx
+++ b/src/lib/factory.tsx
@@ -148,11 +148,12 @@ export function createPushModal<T>({ modals }: CreatePushModalOptions<T>) {
     [K in keyof T]: T[K];
     // eslint-disable-next-line @typescript-eslint/ban-types
   } & {};
-  type GetComponentProps<T> = T extends { Component: React.ComponentType<infer P> }
+  type GetComponentProps<T> = T extends
+    | React.ComponentType<infer P>
+    | React.Component<infer P>
+    | { Component: React.ComponentType<infer P> }
     ? P
-    : T extends React.ComponentType<infer P> | React.Component<infer P>
-      ? P
-      : never;
+    : never;
   type IsObject<T> =
     Prettify<T> extends Record<string | number | symbol, unknown> ? Prettify<T> : never;
   type HasKeys<T> = keyof T extends never ? never : T;

--- a/src/lib/factory.tsx
+++ b/src/lib/factory.tsx
@@ -144,20 +144,27 @@ export function createPushModal<T>({ modals }: CreatePushModalOptions<T>) {
     );
   }
 
+  type Prettify<T> = {
+    [K in keyof T]: T[K];
+    // eslint-disable-next-line @typescript-eslint/ban-types
+  } & {};
   type GetComponentProps<T> = T extends { Component: React.ComponentType<infer P> }
-    ? T extends { Component: React.ComponentType<infer P2> }
-      ? P2
-      : never
+    ? P
     : T extends React.ComponentType<infer P> | React.Component<infer P>
       ? P
       : never;
-  type GetDefinedProps<T> = T extends Record<string | number | symbol, unknown> ? T : never;
+  type IsObject<T> =
+    Prettify<T> extends Record<string | number | symbol, unknown> ? Prettify<T> : never;
+  type HasKeys<T> = keyof T extends never ? never : T;
 
-  const pushModal = <T extends StateItem['name'], B extends GetComponentProps<(typeof modals)[T]>>(
+  const pushModal = <
+    T extends StateItem['name'],
+    B extends Prettify<GetComponentProps<(typeof modals)[T]>>,
+  >(
     name: T,
-    ...args: GetDefinedProps<B> extends never
+    ...args: HasKeys<IsObject<B>> extends never
       ? // No props provided
-        [props?: undefined]
+        []
       : // Props provided
         [props: B]
   ) => {
@@ -179,9 +186,9 @@ export function createPushModal<T>({ modals }: CreatePushModalOptions<T>) {
     B extends GetComponentProps<(typeof modals)[T]>,
   >(
     name: T,
-    ...args: GetDefinedProps<B> extends never
+    ...args: HasKeys<IsObject<B>> extends never
       ? // No props provided
-        [props?: undefined]
+        []
       : // Props provided
         [props: B]
   ) => {


### PR DESCRIPTION
I noticed again that you've listed an issue in the README, and I tackled it, and improved some code

### What changed

#### First - `GetComponentProps` simplification

I noticed you've changed the `GetComponentProps` type, but it had an unnecessary check, so I refactored it, since it works the exact same way but simpler.

```ts
// Before:
type GetComponentProps<T> = T extends { Component: React.ComponentType<infer P> }
    ? T extends { Component: React.ComponentType<infer P2> }
      ? P2
      : never
    : T extends React.ComponentType<infer P> | React.Component<infer P>
      ? P
      : never;

// After:
type GetComponentProps<T> = T extends
    | React.ComponentType<infer P>
    | React.Component<infer P>
    | { Component: React.ComponentType<infer P> }
    ? P
    : never;
```
#### Second - Optional `props`

I noticed you've removed the third parameters(options), so it allowed me to completely remove the second parameter if the component accepts no Props. So now, the type does not even show `props?: undefined` on hover

Before:
![image](https://github.com/lindesvard/pushmodal/assets/86835927/71ed29db-862d-4fd8-913a-41528e5eae9c)
After:
![image](https://github.com/lindesvard/pushmodal/assets/86835927/01969cf3-e7ce-46ae-af39-d53c2800c0a2)

### Third - Supporting interfaces

Since interfaces are taking literally

```ts
// This
interface FakeInterface {
  a: "b"
}
// Does not extend `Record<string, unknown>`
```

The way I've figured out was to use a util type called `Prettify` that takes the interface prop and makes it something that extends `Record<string, unknown>`, that way we can verify it.

I also updated the way we check if the props is an object with the `IsObj` util, that checks if the obj has keys, if not, it is not an object, and will return `never`

### Example

You can take this code, and paste it in your editor to check the types working(please, do test it, I may have missed something I didn't noticed).

```ts
interface CompProps1 {}

interface CompProps2 {
  c: 'd';
}

type CompProps3 = {
  d: 'e';
};

type CompProps4 = undefined;
type CompProps5 = null;
type CompProps6 = {};

type A = HasKeys<IsObject<CompProps1>>; // never
type B = HasKeys<IsObject<CompProps2>>; // { c: "d" }
type C = HasKeys<IsObject<CompProps3>>; // { d: "e" }
type D = HasKeys<IsObject<CompProps4>>; // never
type E = HasKeys<IsObject<CompProps5>>; // never
type F = HasKeys<IsObject<CompProps6>>; // never

```

Again, thanks for making this library and spending your time mantaining it 😄
