### PR TITLE
replace useEffect with useLayoutEffect to avoid state flicker

### DIFF
--- a/src/lib/responsive.tsx
+++ b/src/lib/responsive.tsx
@@ -1,5 +1,5 @@
 import { DialogContentProps, DialogProps } from '@radix-ui/react-dialog';
-import { useEffect, useState } from 'react';
+import { useLayoutEffect, useState } from 'react';
 
 type WrapperProps = DialogProps;
 type ContentProps = Omit<DialogContentProps, 'onAnimationEnd'> & {
@@ -21,7 +21,7 @@ export function createResponsiveWrapper({ mobile, desktop, breakpoint = 640 }: O
   function useIsMobile() {
     const [isMobile, setIsMobile] = useState(false);
 
-    useEffect(() => {
+    useLayoutEffect(() => {
       const checkDevice = (event: MediaQueryList | MediaQueryListEvent) => {
         setIsMobile(event.matches);
       };


### PR DESCRIPTION
Replace `useEffect` with `useLayoutEffect` to avoid initial render of the component with `mobile = false` which leads to a flicker until useEffect is evaluated.

fixes https://github.com/lindesvard/pushmodal/issues/12